### PR TITLE
Added Wall replaceTag to fence defs

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Fences.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Fences.xml
@@ -3,6 +3,9 @@
   <ThingDef Name="FencesAFBuildingBase" Abstract="True">
     <category>Building</category>
     <thingClass>Building</thingClass>
+    <replaceTags>
+      <li>Wall</li>
+    </replaceTags>
     <soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
     <selectable>true</selectable>
     <drawerType>MapMeshAndRealTime</drawerType>


### PR DESCRIPTION
This is a feature of 1.6, where they have [Replace Stuff](https://steamcommunity.com/sharedfiles/filedetails/?id=3526354009) lite built into RimWorld. Someone requested that I add support for this mod to have replacements, instead I think it's better if we implement the tag in this mod.
<img width="727" height="191" alt="image" src="https://github.com/user-attachments/assets/3f9b6020-dd7f-4be4-b898-4a014d7a5426" />
